### PR TITLE
Only backend flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ root folder to start with this option:
     cd /path/to/clientlib
     yarn install
     run-e2e.sh -l
+
+## Running only the backend
+
+If you only want to run the backend without automatically running the e2e tests,
+use the option `-b`. This can be used for running the e2e tests manually.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,8 @@ services:
       - internal
     expose:
       - "8545"
+    ports:
+      - "127.0.0.1:8545:8545"
     volumes:
       - shared:/shared
     command: >

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -25,6 +25,7 @@ while getopts "lpcb" opt; do
         p)  pull=1
             ;;
         c)  coverage=1
+            ;;
         b)  only_backend=1
             ;;
     esac

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -17,7 +17,7 @@ use_local_yarn=0
 pull=0
 coverage=0
 only_backend=0
-while getopts "lpb" opt; do
+while getopts "lpcb" opt; do
     case "$opt" in
         l)  use_local_yarn=1
             test -e src/Trustline.ts || die "run-e2e.sh: local test runs must be started from the clientlib repository"
@@ -26,7 +26,6 @@ while getopts "lpb" opt; do
             ;;
         c)  coverage=1
         b)  only_backend=1
-            echo "ONLY BACKEND"
             ;;
     esac
 done


### PR DESCRIPTION
It happened that I need this flag for convenience when testing for example the clientlib with a injected web3 signer via MetaMask. Also this flag makes it easier to run single end2end test suits without the need of restarting all docker containers.