### PR TITLE
upgrade parity to 2.3.9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - internal
 
   parity:
-    image: parity/parity:v2.2.9
+    image: parity/parity:v2.3.9
     container_name: parity
     restart: unless-stopped
     networks:


### PR DESCRIPTION
this version is at least compatible with the trustlines testchain.