### PR TITLE
Update parity version used to 2.6.3-beta to have petersburg etips in

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - internal
 
   parity:
-    image: parity/parity:v2.4.6
+    image: parity/parity:v2.6.3-beta
     container_name: parity
     restart: unless-stopped
     networks:


### PR DESCRIPTION
the dev chain spec file