### PR TITLE
Copies the addresses.json file containing the factory and implementat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,8 @@ services:
       - internal
     links:
       - "relay"
+    volumes:
+      - shared:/clientlib/tests/e2e-config
 
 networks:
   internal:

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -58,7 +58,6 @@ mydir=$(mktemp -td end2end.XXXXXX)
 trap "cleanup" EXIT
 trap "exit 1" SIGINT SIGTERM
 
-#test
 # unset environment variables set in .env, otherwise we overwrite .env
 unset PGHOST PGUSER POSTGRES_USER PGDATABASE PGPASSWORD POSTGRES_PASSWORD
 
@@ -97,7 +96,7 @@ if [[ ${only_backend} -eq 0 ]]; then
   else
     cd "${cwd}" || die "cd failed"
     # Copies the file addresses.json in the shared volume to the local directory cwd/tests/e2e-config
-    docker run --rm -v $PWD/tests/e2e-config:/dest -v end2end_shared:/source -w /source alpine cp addresses.json /dest
+    docker run --rm -v "$PWD"/tests/e2e-config:/dest -v end2end_shared:/source -w /source alpine cp addresses.json /dest
     yarn run test:e2e | tee "${mydir}/output.txt"
     result="${PIPESTATUS[0]}"
   fi

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -95,6 +95,8 @@ if [[ ${only_backend} -eq 0 ]]; then
     fi
   else
     cd "${cwd}" || die "cd failed"
+    # Copies the file addresses.json in the shared volume to the local directory cwd/tests/e2e-config
+    docker run --rm -v ($PWD)/tests/e2e-config:/dest -v end2end_shared:/source -w /source alpine cp addresses.json /dest
     yarn run test:e2e | tee "${mydir}/output.txt"
     result="${PIPESTATUS[0]}"
   fi

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -58,6 +58,7 @@ mydir=$(mktemp -td end2end.XXXXXX)
 trap "cleanup" EXIT
 trap "exit 1" SIGINT SIGTERM
 
+#test
 # unset environment variables set in .env, otherwise we overwrite .env
 unset PGHOST PGUSER POSTGRES_USER PGDATABASE PGPASSWORD POSTGRES_PASSWORD
 
@@ -96,7 +97,7 @@ if [[ ${only_backend} -eq 0 ]]; then
   else
     cd "${cwd}" || die "cd failed"
     # Copies the file addresses.json in the shared volume to the local directory cwd/tests/e2e-config
-    docker run --rm -v ($PWD)/tests/e2e-config:/dest -v end2end_shared:/source -w /source alpine cp addresses.json /dest
+    docker run --rm -v $PWD/tests/e2e-config:/dest -v end2end_shared:/source -w /source alpine cp addresses.json /dest
     yarn run test:e2e | tee "${mydir}/output.txt"
     result="${PIPESTATUS[0]}"
   fi


### PR DESCRIPTION
Copies the addresses.json file containing the factory and implementation addresses required for deploying an identity proxy in the e2e tests.

This file is created by the contracts docker container and put in a shared folder which is easier mounted to the e2e container or copied locally.