### PR TITLE
Fix relay configuration defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "127.0.0.1:5000:5000"
     networks:
       - internal
-    command: ["--config", "/shared/config.toml", "--addresses", "/shared/addresses.json"]
+    command: ["--config", "/shared/config.toml"]
     restart: unless-stopped
 
   index:

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -83,13 +83,40 @@ first_network_address=$(sed -E 's/\{"networks": \["(0x[0-9,a-f,A-F]+)".*/\1/' $a
 
 cat >${relay_config} <<EOF
 [relay]
+addresses_filepath = "/shared/addresses.json"
 update_indexed_networks_interval = 5
+
+[relay.gas_price_computation]
+method = "rpc"
+gas_price = 0
 
 [trustline_index]
 enable = true
 full_sync_interval = 300
+event_query_timeout = 20
+
+[tx_relay]
+enable = true
+
+[exchange]
+enable = true
+
+[node_rpc]
+host = "node"
+port = 8545
+use_ssl = false
 
 [faucet]
+enable = true
+
+[push_notification]
+enable = false
+
+[rest]
+port = 5000
+host = "relay"
+
+[messaging]
 enable = true
 
 [delegate]
@@ -99,11 +126,6 @@ enable_deploy_identity = true
 [[delegate.fees]]
 base_fee = 1
 currency_network = "${first_network_address}"
-
-[node_rpc]
-host = "node"
-port = 8545
-use_ssl = false
 EOF
 
 rm -f $address_file


### PR DESCRIPTION
Reaction to [this comment](https://github.com/trustlines-protocol/end2end/pull/21#pullrequestreview-364136832) of the previous PR #21.
Related to the [current version](https://github.com/trustlines-protocol/relay/blob/3381e64b95661e56150f2fa9aa1cc83156ef4c43/config.toml) of the example relay configuration, slightly adopted for the end2end tests.