### PR TITLE
Remove `event_query_timeout` from the relay config

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -115,7 +115,6 @@ gas_price = 0
 [trustline_index]
 enable = true
 full_sync_interval = 300
-event_query_timeout = 20
 
 [tx_relay]
 enable = true


### PR DESCRIPTION
This is needed to fix the e2e test broken by https://github.com/trustlines-protocol/relay/pull/498