### PR TITLE
Allow to configure used images via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ or directly. For more information check the docker-compose documentation.
 To run the tests against for example a different relay version, the command is
 
     TL_RELAY_IMAGE=trustlines/relay:0.14.0 ./run-e2e.sh
+
+## Pull latest images
+To ensure you run the tests against the latest images, you can use the option `-p` to pull
+the latest images from docker hub.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,18 @@ use the option `-b`. This can be used for running the e2e tests manually.
 
 ## Running tests with delegation fees
 If you want to run tests with delegation fees provided the `-f` flag.
+
+## Running tests against specific (relay, clientlib, index, contracts) versions
+If you want to use a specific image (locally or from docker hub) you can use environment
+variables to configure the image. The following env vars exist with their respective defaults.
+
+    TL_RELAY_IMAGE=trustlines/relay
+    TL_INDEX_IMAGE=trustlines/py-eth-index
+    TL_CONTRACTS_IMAGE=trustlines/contracts
+    TL_E2E_IMAGE=trustlines/e2e
+
+You can provide the env variables either via an `.env` file beside the docker-compose file
+or directly. For more information check the docker-compose documentation.
+To run the tests against for example a different relay version, the command is
+
+    TL_RELAY_IMAGE=trustlines/relay:0.14.0 ./run-e2e.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command: ["true"]
 
   relay:
-    image: trustlines/relay
+    image: ${TL_RELAY_IMAGE:-trustlines/relay}
     container_name: relay
     environment:
       - TRUSTLINES_SYNC_TX_RELAY=1
@@ -33,7 +33,7 @@ services:
     restart: unless-stopped
 
   index:
-    image: trustlines/py-eth-index
+    image: ${TL_INDEX_IMAGE:-trustlines/py-eth-index}
     networks:
       - internal
     links:
@@ -48,7 +48,7 @@ services:
     command: runsync --jsonrpc http://node:8545 --waittime 200
 
   createtables:
-    image: trustlines/py-eth-index
+    image: ${TL_INDEX_IMAGE:-trustlines/py-eth-index}
     restart: on-failure
     networks:
       - internal
@@ -62,7 +62,7 @@ services:
     command: createtables
 
   init:
-    image: trustlines/py-eth-index
+    image: ${TL_INDEX_IMAGE:-trustlines/py-eth-index}
     restart: on-failure
     networks:
       - internal
@@ -113,7 +113,7 @@ services:
     # https://github.com/trustlines-protocol/blockchain/commit/c821f16c3ec9f54e15fa89f4c8dae6ffa64ded01
 
   contracts:
-    image: trustlines/contracts
+    image: ${TL_CONTRACTS_IMAGE:-trustlines/contracts}
     command: ["test", "--file", "/shared/addresses.json", "--jsonrpc", "http://node:8545"]
     container_name: contracts
     links:
@@ -128,7 +128,8 @@ services:
     networks:
       - internal
   e2e:
-    image: trustlines/e2e
+    image: ${TL_E2E_IMAGE:-trustlines/e2e}
+
     container_name: e2e
     networks:
       - internal


### PR DESCRIPTION
To make it possible to easily run the e2e tests against different
versions of relay, clientlib, ... allow to specify the used image via
env variable. For docker-compose they can be provided either by a .env
file or the usual way TL_<>_IMAGE=<image> ./run-e2e.sh.