### PR TITLE
Add volume to relay image to export end2end coverage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,12 @@ services:
       - "postgres:db"
     volumes:
       - shared:/shared
+      - ./end2end-coverage:/end2end-coverage
     ports:
       - "127.0.0.1:5000:5000"
     networks:
       - internal
-    command: ["--config", "/shared/config.toml"]
+    command: ["--config", "/shared/config.toml", "--coverage"]
     restart: unless-stopped
 
   index:


### PR DESCRIPTION
Add volume and option to run the relay with creation of a code coverage report.
See: https://github.com/trustlines-protocol/relay/pull/561