### PR TITLE
Use default abi for `ethindex importabi` in e2e tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     volumes:
       - shared:/shared
       - abi:/abi
-    command: importabi --contracts /abi/contracts.json --addresses /shared/addresses.json
+    command: importabi --addresses /shared/addresses.json
 
   postgres:
     image: postgres


### PR DESCRIPTION
Requires: https://github.com/trustlines-protocol/py-eth-index/pull/64