### PR TITLE
Replace links with a bridge network in docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - setup_remote_docker
+          version: 19.03.14
       - checkout
       - config-path
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - setup_remote_docker:
-          version: 19.03.14
+          version: 20.10.7
       - checkout
       - config-path
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
     executor: ubuntu-builder
     working_directory: ~/repo
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
           version: 19.03.14
       - checkout
       - config-path

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-PGHOST=db
+PGHOST=postgres
 PGUSER=trustlines_test
 POSTGRES_USER=trustlines_test
 PGDATABASE=trustlines_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ services:
       - PGUSER
       - PGDATABASE
       - PGPASSWORD
-    links:
-      - "openethereum:node"
-      - "postgres:db"
+    depends_on:
+      - openethereum
+      - postgres
     volumes:
       - shared:/shared
       - ./end2end-coverage:/end2end-coverage
@@ -37,24 +37,24 @@ services:
     image: ${TL_INDEX_IMAGE:-trustlines/py-eth-index}
     networks:
       - internal
-    links:
-      - "postgres:db"
-      - "openethereum:node"
+    depends_on:
+      - postgres
+      - openethereum
     environment:
       - PGHOST
       - PGUSER
       - PGDATABASE
       - PGPASSWORD
     restart: unless-stopped
-    command: runsync --jsonrpc http://node:8545 --waittime 200
+    command: runsync --jsonrpc http://openethereum:8545 --waittime 200
 
   createtables:
     image: ${TL_INDEX_IMAGE:-trustlines/py-eth-index}
     restart: on-failure
     networks:
       - internal
-    links:
-      - "postgres:db"
+    depends_on:
+      - postgres
     environment:
       - PGHOST
       - PGUSER
@@ -67,8 +67,8 @@ services:
     restart: on-failure
     networks:
       - internal
-    links:
-      - "postgres:db"
+    depends_on:
+      - postgres
       - createtables
     environment:
       - PGHOST
@@ -115,10 +115,10 @@ services:
 
   contracts:
     image: ${TL_CONTRACTS_IMAGE:-trustlines/contracts}
-    command: ["test", "--file", "/shared/addresses.json", "--jsonrpc", "http://node:8545", "--gas-price", "0"]
+    command: ["test", "--file", "/shared/addresses.json", "--jsonrpc", "http://openethereum:8545", "--gas-price", "0"]
     container_name: contracts
-    links:
-      - "openethereum:node"
+    depends_on:
+      - openethereum
     volumes:
       - shared:/shared
       - type: volume
@@ -134,14 +134,15 @@ services:
     container_name: e2e
     networks:
       - internal
-    links:
-      - "relay"
+    depends_on:
+      - relay
     volumes:
       - shared:/clientlib/tests/e2e-config
 
 networks:
   internal:
     external: false
+    driver: bridge
 
 volumes:
   abi:

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -129,7 +129,7 @@ enable = true
 enable = true
 
 [node_rpc]
-host = "node"
+host = "openethereum"
 port = 8545
 use_ssl = false
 


### PR DESCRIPTION
It appears links are deprecated and do not work with
docker-compose v2.0.0rc3, we use a bridge network and depends_on
instead.