### PR TITLE
Fix containers not starting on circleCI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,11 +144,11 @@ services:
 
   nginx:
     image: nginx:1.21-alpine
+    container_name: nginx
     hostname: nginx
     ports:
       - "8001:8000"
     volumes:
-      - ./docker/gnosis-relay-service/nginx/safe_service.conf:/etc/nginx/nginx.conf:ro
       - nginx-shared:/nginx
     depends_on:
       - safe-relay-service
@@ -164,19 +164,18 @@ services:
 
   safe-relay-service:
     image: ${TL_SAFE_RELAY_SERVICE_IMAGE}
+    container_name: safe-relay-service
     env_file:
       - .env.local.relay-service
     depends_on:
       - node
       - db
       - redis
-    working_dir: /app
     ports:
       - "8888:8888"
     volumes:
       - nginx-shared:/nginx
-      - ./docker/gnosis-relay-service/web/run_web.sh:/docker/web/run_web.sh
-    command: /docker/web/run_web.sh
+    command: /app/docker/web/run_web.sh
     networks:
       - internal
 

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -172,11 +172,14 @@ docker-compose up createtables
 docker-compose up init
 docker-compose up -d index relay
 
+docker cp ./docker/gnosis-relay-service/web/run_web.sh safe-relay-service:/app/docker/web/run_web.sh
+docker cp ./docker/gnosis-relay-service/nginx/safe_service.conf nginx:/etc/nginx/nginx.conf
+
 docker-compose up -d nginx safe-relay-service worker scheduler
 
 if [[ ${only_backend} -eq 0 ]]; then
   sleep 3
-  docker-compose logs -t -f node index relay e2e &
+  docker-compose logs -t -f node index relay nginx safe-relay-service worker scheduler &
   if [[ ${use_local_yarn} -eq 0 ]]; then
     docker-compose up -d e2e
     docker_wait_output=$(docker wait e2e)


### PR DESCRIPTION
The containers were failing to start due to the local volumes mounting we did in docker-compose. Instead of mounting volumes we now copy the files in the run-e2e.sh file.